### PR TITLE
feat: service terms API

### DIFF
--- a/src/main/java/com/healthier/admin/common/ApiResponse.java
+++ b/src/main/java/com/healthier/admin/common/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.healthier.admin.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    public static final ApiResponse<Void> DEFAULT_OK =
+            new ApiResponse<>(true, "Operation successful", null, null);
+
+    private boolean success;
+    private String message;
+    private T data;
+    private Metadata metadata;
+
+    @Getter
+    @Setter
+    public static class Metadata {
+        private String requestId;
+        private String timestamp;
+
+        public Metadata(String requestId, String timestamp) {
+            this.requestId = requestId;
+            this.timestamp = timestamp;
+        }
+    }
+
+    public static <T> ApiResponse<T> createSuccessResponse(T data) {
+        return new ApiResponse<>(true, "Request processed successfully", data, null);
+    }
+}

--- a/src/main/java/com/healthier/admin/domain/serviceTerms/controller/ServiceTermsController.java
+++ b/src/main/java/com/healthier/admin/domain/serviceTerms/controller/ServiceTermsController.java
@@ -1,0 +1,44 @@
+package com.healthier.admin.domain.serviceTerms.controller;
+
+import com.healthier.admin.common.ApiResponse;
+import com.healthier.admin.domain.serviceTerms.dto.ServiceTermsDto;
+import com.healthier.admin.domain.serviceTerms.service.ServiceTermsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "약관 API", description = "약관 API 입니다.")
+@CrossOrigin
+@RequestMapping(value = "/serviceTerms")
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+public class ServiceTermsController {
+    private final ServiceTermsService serviceTermsService;
+
+    // 서비스 약관 전체 조회
+    @Operation(summary = "서비스 약관 전체 조회")
+    @GetMapping("/")
+    public ApiResponse<List<ServiceTermsDto>> getAllServiceTerms() {
+        return ApiResponse.createSuccessResponse(serviceTermsService.getAllServiceTerms());
+    }
+
+    // 서비스 약관 개별 조회
+    @Operation(summary = "서비스 약관 개별 조회")
+    @GetMapping("/{id}")
+    public ApiResponse<ServiceTermsDto> getServiceTerms(@PathVariable Long id) {
+        return ApiResponse.createSuccessResponse(serviceTermsService.getServiceTerms(id));
+    }
+
+    // 서비스 약관 수정
+    @Operation(summary = "서비스 약관 수정")
+    @PatchMapping("/{id}")
+    public ApiResponse<?> updateServiceTerms(
+            @PathVariable Long id, @RequestBody ServiceTermsDto serviceTermsDto) {
+        serviceTermsService.updateServiceTerms(id, serviceTermsDto);
+        return ApiResponse.DEFAULT_OK;
+    }
+}

--- a/src/main/java/com/healthier/admin/domain/serviceTerms/domain/ServiceTerms.java
+++ b/src/main/java/com/healthier/admin/domain/serviceTerms/domain/ServiceTerms.java
@@ -14,8 +14,14 @@ public class ServiceTerms extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private TermsType type;
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    public void updateServiceTerms(TermsType type, String content) {
+        this.type = type;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/healthier/admin/domain/serviceTerms/domain/TermsType.java
+++ b/src/main/java/com/healthier/admin/domain/serviceTerms/domain/TermsType.java
@@ -1,6 +1,15 @@
 package com.healthier.admin.domain.serviceTerms.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum TermsType {
-    TERMS_OF_USE,
-    PRIVACY_POLICY
+    TERMS_OF_USE("서비스 이용약관"),
+    PRIVACY_POLICY("개인정보 처리방침");
+
+    private String description;
+
+    TermsType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/healthier/admin/domain/serviceTerms/dto/ServiceTermsDto.java
+++ b/src/main/java/com/healthier/admin/domain/serviceTerms/dto/ServiceTermsDto.java
@@ -1,0 +1,35 @@
+package com.healthier.admin.domain.serviceTerms.dto;
+
+import com.healthier.admin.domain.serviceTerms.domain.ServiceTerms;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ServiceTermsDto {
+    private Long id;
+    private String type;
+    private String content;
+    private LocalDateTime modifiedAt;
+
+    // Preview
+    public static ServiceTermsDto fromPreview(ServiceTerms serviceTerms) {
+        return new ServiceTermsDto(
+                serviceTerms.getId(),
+                serviceTerms.getType().getDescription(),
+                null,
+                serviceTerms.getModifiedDate());
+    }
+
+    // Detail
+    public static ServiceTermsDto fromDetail(ServiceTerms serviceTerms) {
+        return new ServiceTermsDto(
+                serviceTerms.getId(),
+                serviceTerms.getType().getDescription(),
+                serviceTerms.getContent(),
+                serviceTerms.getModifiedDate());
+    }
+}

--- a/src/main/java/com/healthier/admin/domain/serviceTerms/service/ServiceTermsService.java
+++ b/src/main/java/com/healthier/admin/domain/serviceTerms/service/ServiceTermsService.java
@@ -1,0 +1,51 @@
+package com.healthier.admin.domain.serviceTerms.service;
+
+import com.healthier.admin.domain.serviceTerms.domain.ServiceTerms;
+import com.healthier.admin.domain.serviceTerms.domain.TermsType;
+import com.healthier.admin.domain.serviceTerms.dto.ServiceTermsDto;
+import com.healthier.admin.domain.serviceTerms.repository.ServiceTermsRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ServiceTermsService {
+    private final ServiceTermsRepository serviceTermsRepository;
+
+    // 서비스 약관 전체 조회 GET
+    public List<ServiceTermsDto> getAllServiceTerms() {
+        return serviceTermsRepository.findAll().stream()
+                .map(ServiceTermsDto::fromPreview)
+                .collect(Collectors.toList());
+    }
+
+    // 서비스 약관 개별 조회 GET
+    public ServiceTermsDto getServiceTerms(Long id) {
+        return serviceTermsRepository
+                .findById(id)
+                .map(ServiceTermsDto::fromDetail)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약관이 존재하지 않습니다."));
+    }
+
+    // 서비스 약관 수정 PATCH
+    @Transactional
+    public void updateServiceTerms(Long id, ServiceTermsDto serviceTermsDto) {
+        ServiceTerms updatedServiceTerms =
+                serviceTermsRepository
+                        .findById(id)
+                        .map(
+                                serviceTerms -> {
+                                    serviceTerms.updateServiceTerms(
+                                            TermsType.valueOf(serviceTermsDto.getType()),
+                                            serviceTermsDto.getContent());
+                                    return serviceTerms;
+                                })
+                        .orElseThrow(() -> new IllegalArgumentException("해당 약관이 존재하지 않습니다."));
+
+        serviceTermsRepository.save(updatedServiceTerms);
+    }
+}

--- a/src/test/java/com/healthier/admin/serviceTerms/ServiceTermsServiceTest.java
+++ b/src/test/java/com/healthier/admin/serviceTerms/ServiceTermsServiceTest.java
@@ -1,0 +1,99 @@
+package com.healthier.admin.serviceTerms;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.healthier.admin.domain.serviceTerms.domain.ServiceTerms;
+import com.healthier.admin.domain.serviceTerms.domain.TermsType;
+import com.healthier.admin.domain.serviceTerms.dto.ServiceTermsDto;
+import com.healthier.admin.domain.serviceTerms.repository.ServiceTermsRepository;
+import com.healthier.admin.domain.serviceTerms.service.ServiceTermsService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceTermsServiceTest {
+
+    @Mock private ServiceTermsRepository serviceTermsRepository;
+
+    @InjectMocks private ServiceTermsService serviceTermsService;
+
+    private ServiceTerms term1, term2;
+    private ServiceTermsDto termsDto1, termsDto2;
+
+    @BeforeEach
+    void setUp() {
+        term1 =
+                ServiceTerms.builder()
+                        .id(1L)
+                        .type(TermsType.TERMS_OF_USE)
+                        .content("서비스 이용약관")
+                        .build();
+
+        term2 =
+                ServiceTerms.builder()
+                        .id(2L)
+                        .type(TermsType.PRIVACY_POLICY)
+                        .content("개인정보 처리방침")
+                        .build();
+
+        termsDto1 = ServiceTermsDto.builder().type("TERMS_OF_USE").content("서비스 이용약관").build();
+
+        termsDto2 = ServiceTermsDto.builder().type("PRIVACY_POLICY").content("개인정보 처리방침").build();
+    }
+
+    @DisplayName("서비스 약관 전체 조회")
+    @Test
+    void getAllServiceTermsTest() {
+        // Given
+        when(serviceTermsRepository.findAll()).thenReturn(Arrays.asList(term1, term2));
+
+        // When
+        List<ServiceTermsDto> result = serviceTermsService.getAllServiceTerms();
+
+        // Then
+        assertEquals(2, result.size());
+
+        assertTrue(result.stream().anyMatch(dto -> dto.getId().equals(term1.getId())));
+        assertTrue(result.stream().anyMatch(dto -> dto.getId().equals(term2.getId())));
+    }
+
+    @DisplayName("서비스 약관 개별 조회")
+    @Test
+    void getServiceTermsTest() {
+        // Given
+        Long id = 1L;
+        when(serviceTermsRepository.findById(id)).thenReturn(Optional.of(term1));
+
+        // When
+        ServiceTermsDto result = serviceTermsService.getServiceTerms(id);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(term1.getId(), result.getId());
+        assertEquals(term1.getContent(), result.getContent());
+    }
+
+    @DisplayName("서비스 약관 수정")
+    @Test
+    void updateServiceTermsTest() {
+        // Given
+        Long id = 1L;
+        when(serviceTermsRepository.findById(id)).thenReturn(Optional.of(term1));
+
+        // When
+        serviceTermsService.updateServiceTerms(id, termsDto1);
+
+        // Then
+        verify(serviceTermsRepository).save(term1);
+    }
+}


### PR DESCRIPTION
### PR 타입
<!-- (하나 이상의 PR 타입을 선택해주세요) -->
- [x] 기능 추가  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
<!-- ex) feat/login -> dev -->
feat/terms -> develop

### 변경 사항
<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
- 서비스 약관 전체 조회 API
- 서비스 약관 개별 조회 API
- 서비스 약관 수정 API 

- 공통 Response 코드로 ApiResponse 클래스를 만들었습니다
```java
    public ApiResponse<T> sampleMethod() {
        return ApiResponse.createSuccessResponse(sampleData);
    }
```
e.g.
```java
// ServiceTermsController.java
    @GetMapping("/")
    public ApiResponse<List<ServiceTermsDto>> getAllServiceTerms() {
        return ApiResponse.createSuccessResponse(serviceTermsService.getAllServiceTerms());
    }
```

- 에러 처리는 IllegalArgumentException 로 에러 메시지만 전달했습니다
```java
// ServiceTermsService.java
    public ServiceTermsDto getServiceTerms(Long id) {
        return serviceTermsRepository
                .findById(id)
                .map(ServiceTermsDto::fromDetail)
                .orElseThrow(() -> new IllegalArgumentException("해당 약관이 존재하지 않습니다."));
    }
```

### 테스트 결과
<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="483" alt="Screenshot 2024-01-23 at 2 45 12 PM" src="https://github.com/healthier-devs/healthier-admin-backend/assets/77188666/ef3074f0-44bc-44ec-a934-974db98f8b88">


### Issue
<!-- ex) close #{Isuee 번호} -->
close #
